### PR TITLE
define('NO_ONLINE', 1); to obscure presence of metrics file from WOL

### DIFF
--- a/prometheus_metrics.php
+++ b/prometheus_metrics.php
@@ -1,6 +1,7 @@
 <?php
 
 define('IN_MYBB', 1);
+define('NO_ONLINE', 1);
 define('THIS_SCRIPT', 'prometheus_metrics.php');
 
 include __DIR__ . '/global.php';


### PR DESCRIPTION
Adds `define('NO_ONLINE', 1);` so that an `Unknown Location` entry is not placed onto the online list, and to obscure the presence of the Prometheus metrics file.